### PR TITLE
fix: validation and documentation for create recipe

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -138,14 +138,6 @@ export default async () => {
           },
         ],
         [
-          import('./recipe/dto/optional-author-request'),
-          {
-            OptionalAuthorRequest: {
-              authorId: { required: false, type: () => Number },
-            },
-          },
-        ],
-        [
           import('./recipe/dto/upload-images-response'),
           {
             UploadImagesResponse: {

--- a/src/recipe/dto/create-recipe-request.ts
+++ b/src/recipe/dto/create-recipe-request.ts
@@ -1,14 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateRecipeRequest {
   @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
   title: string;
 
   @IsOptional()
+  @IsString()
+  @ApiProperty()
   description?: string;
 
   @IsNotEmpty()
+  @IsString()
   @ApiProperty({
     description: 'Each ingredient should be in a new line',
     example: 'Item 1\nItem 2\nItem 3',
@@ -16,6 +21,7 @@ export class CreateRecipeRequest {
   ingredients: string;
 
   @IsNotEmpty()
+  @IsString()
   @ApiProperty({
     description: 'Each step should be in a new line',
     example: 'Step 1\nStep 2\nStep 3',


### PR DESCRIPTION
### Issue: 
None of the fields except for isPublic are being validated for the correct type. Response is code 500 if we send a request with with incorrect type in title, ingredients, preparation or description. Response should be code 400 instead.

The documentation is also missing title and description in the schema.

