### PR TITLE
fix: account activation link and token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ commands:
             AWS_REGION="$AWS_REGION"
             AWS_S3_BUCKET="$AWS_S3_BUCKET"
             AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+            BASE_URL="$BASE_URL"
             BCRYPT_SALT="$BCRYPT_SALT"
             DATABASE_URL="$DATABASE_URL"
             ENVIRONMENT="$ENVIRONMENT"

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -23,7 +23,6 @@ import qrcode from 'qrcode';
 import { TwoFactorAuth } from '@prisma/client';
 import { TwoFactorAuthRepository } from './twoFactorAuth.repository';
 import { PendingUsersRepository } from '../user/pending-user.repository';
-import { isJwtTokenStructureValid } from '../utils/jwt-utils';
 
 @Injectable()
 export class AuthService {
@@ -125,10 +124,6 @@ export class AuthService {
   ): Promise<{ id: number }> {
     const invalidTokenMessage =
       'Invalid token. Please provide a valid token to activate account';
-
-    if (!isJwtTokenStructureValid(jwtToken)) {
-      throw new UnauthorizedException(invalidTokenMessage);
-    }
 
     try {
       return this.jwtService.verifyAsync(jwtToken, {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -24,7 +24,6 @@ import { TwoFactorAuth } from '@prisma/client';
 import { TwoFactorAuthRepository } from './twoFactorAuth.repository';
 import { PendingUsersRepository } from '../user/pending-user.repository';
 import { isJwtTokenStructureValid } from 'src/utils/jwt-utils';
-import { NotFoundError } from 'rxjs';
 
 @Injectable()
 export class AuthService {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -23,7 +23,7 @@ import qrcode from 'qrcode';
 import { TwoFactorAuth } from '@prisma/client';
 import { TwoFactorAuthRepository } from './twoFactorAuth.repository';
 import { PendingUsersRepository } from '../user/pending-user.repository';
-import { isJwtTokenStructureValid } from 'src/utils/jwt-utils';
+import { isJwtTokenStructureValid } from '../utils/jwt-utils';
 
 @Injectable()
 export class AuthService {

--- a/src/utils/jwt-utils.ts
+++ b/src/utils/jwt-utils.ts
@@ -1,3 +1,0 @@
-export function isJwtTokenStructureValid(token: string) {
-  return token?.split('.').length === 3;
-}

--- a/src/utils/jwt-utils.ts
+++ b/src/utils/jwt-utils.ts
@@ -1,0 +1,3 @@
+export function isJwtTokenStructureValid(token: string) {
+  return token?.split('.').length === 3;
+}


### PR DESCRIPTION
### FIX: 
- Code 500 when we send an invalid token value or no token at all. The error should be handled.

- Email has a malformed activation link "undefined/auth/activate-account/"